### PR TITLE
Write browser versions explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,20 @@ const lineup = builder.build(document.body);
 Supported Browsers
 ------------------
 
- * Chrome (best performance)
- * Firefox Quantum
- * Edge 16
+ * Chrome 64+ (best performance)
+ * Firefox 57+
+ * Edge 16+
  
 
 API Documentation
 -----------------
 
-see [Develop API documentation](https://sgratzl.github.io/lineupjs_docs/cleanup/docs)
+See [Develop API documentation](https://sgratzl.github.io/lineupjs_docs/cleanup/docs)
 
 Demos
 -----
 
-see [Develop Demos](https://sgratzl.github.io/lineupjs_docs/cleanup)
+See [Develop Demos](https://sgratzl.github.io/lineupjs_docs/cleanup)
 
 
 Dependencies


### PR DESCRIPTION
I think it's better to state the supported browser versions explicitly. Then it's easer for the reader to know if he has the correct browser.